### PR TITLE
Update build script

### DIFF
--- a/update
+++ b/update
@@ -21,7 +21,7 @@ build-script() {
 }
 
 if [[ ! -d $GITREPO ]]; then
-  git clone $GITURL $GITREPO
+  git clone $GITURL $GITREPO --depth 10
 fi
 
 cd $GITREPO


### PR DESCRIPTION
Only clone the last N commits will be enough to build the target,
can make the process faster, and save the bandwidth.

(N = 10 here, depends on the build frequency)
