### PR TITLE
Publish to npm as highlight.js-cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "highlight.js-cdn",
+  "description": "Syntax highlighting with language autodetection.",
+  "keywords": [
+    "highlight",
+    "syntax"
+  ],
+  "homepage": "https://highlightjs.org/",
+  "version": "9.12.0",
+  "author": {
+    "name": "Ivan Sagalaev",
+    "email": "maniac@softwaremaniacs.org"
+  },
+  "bugs": {
+    "url": "https://github.com/isagalaev/highlight.js/issues"
+  },
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/isagalaev/highlight.js.git"
+  },
+  "main": "./build/highlight.min.js",
+  "files": [
+    "build/"
+  ]
+}

--- a/update
+++ b/update
@@ -31,7 +31,7 @@ fi
 cd $GITREPO
 
 # Grab the latest tagged version
-TAGNAME=`git tag --list | sort --reverse | head -n 1`
+TAGNAME=`git tag --list | sort --version-sort --reverse | head -n 1`
 BUILDDIR="../build"
 
 git pull
@@ -47,8 +47,13 @@ git checkout master
 
 cd ..
 
+# Update version in package.json
+sed -i "s#\"version\": \".*\"#\"version\": \"${TAGNAME}\"#" package.json
+
 git add --all
 git commit -m "Update to version ${TAGNAME}"
 git tag --annotate $TAGNAME -m "Version ${TAGNAME}"
 git push origin
 git push --tags
+
+npm publish


### PR DESCRIPTION
Add a `package.json`, and update the `update` script to publish the built files to npm as `highlight.js-cdn`.

Resolve [highlight.js#678](https://github.com/isagalaev/highlight.js/issues/678#issuecomment-72732720).

My personal usecase: use local assets under `node_moudles` in development and use CDN in production.